### PR TITLE
Add devcontainer to allow preview

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Make a prettier image name
+	"runArgs": ["--name", "trackyverse-web"],
+
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:noble",
+	"features": {
+    "ghcr.io/rocker-org/devcontainer-features/quarto-cli:latest": {},
+		"ghcr.io/rocker-org/devcontainer-features/r-apt:0": {}
+  },
+
+	"postStartCommand": "quarto preview"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly


### PR DESCRIPTION
Devcontainer contains R and Quarto, allowing one to preview PRs on GH Codespaces without building locally.

Note that too much of this CAN INCUR CHARGES, so be carefule